### PR TITLE
Add retrieved date to references

### DIFF
--- a/WikidataComplete-Gadget.js
+++ b/WikidataComplete-Gadget.js
@@ -355,6 +355,8 @@ importScript('User:Gabinguo/celebration.js');
                     let arg3 = e.target.getAttribute('url-id');
                     let arg4 = e.target.getAttribute('qualifier-id');
                     let arg5 = e.target.getAttribute('ref-id');
+                    let today = new Date();
+                    today.setUTCHours(0, 0, 0, 0);
                     var snak = JSON.stringify({ "entity-type": 'item', "numeric-id": arg3.substring(32) });
                     var snaksorder = ["P4656","P1683"];
                     var sourceSnaks = {
@@ -367,6 +369,24 @@ importScript('User:Gabinguo/celebration.js');
                                     "type": "string"
                                 },
                                 "datatype": "url"
+                            }
+                        ],
+                        "P813": [
+                            {
+                                "snaktype": "value",
+                                "property": "P813",
+                                "datavalue": {
+                                    "value": {
+                                        "time": "+" + today.toISOString().replace(/\.\d*Z$/, 'Z'),
+                                        "timezone": 0,
+                                        "before": 0,
+                                        "after": 0,
+                                        "precision": 11,
+                                        "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                                    },
+                                    "type": "time"
+                                },
+                                "datatype": "time"
                             }
                         ],
                         "P1683": [


### PR DESCRIPTION
---

This is kind of a proof of concept; potential issues:

- the retrieved date is not shown in the reference before you save / publish the statement
- I’m not sure if the retrieved date is accurate; maybe it should be the date when the WikidataComplete API inferred the item to be suggested?

Also, ideally the Wikimedia import URL should be a permalink, but that’s harder to do.